### PR TITLE
Fix profile info storage object in HYDRA.ps1

### DIFF
--- a/HYDRA.ps1
+++ b/HYDRA.ps1
@@ -107,7 +107,9 @@ do {
                             $profileFiles = Get-ChildItem -Path $profilePath -File -Recurse -ErrorAction Stop
                             $newestFile = $profileFiles | Sort-Object LastWriteTime -Descending | Select-Object -First 1
                             $ageDays = (New-TimeSpan -Start $newestFile.LastWriteTime -End (Get-Date)).Days
-                            $userAges += [ordered]@{ Profile = $profilePath; Age = $ageDays }
+                            # Store profile information as a PSCustomObject so
+                            # that it exposes properties we can access later
+                            $userAges += [PSCustomObject]@{ Profile = $profilePath; Age = $ageDays }
                         }
                         catch {
                             continue


### PR DESCRIPTION
## Summary
- fix profile metadata storage to create objects with properties
- ensure newline at end of file

## Testing
- `pwsh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b636ead88330b64e8d49f5ce5a83